### PR TITLE
fix(tomlua.env): moved to https://github.com/BirdeeHub/lua-osenv

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,10 +82,10 @@ Install to `PREFIX` (`LIBDIR`, `LUADIR`, `BINDIR`) |
 `LUADIR` just contains type definitions for `lua_ls`
 
 ```bash
-make install prefix=/path/to/install/location LUADIR=/dev/null
+make install PREFIX=/path/to/install/location LUADIR=/dev/null
 ```
 
-### Useage
+### Usage
 
 #### Options
 

--- a/src/env.c
+++ b/src/env.c
@@ -42,7 +42,22 @@ static int env__index(lua_State *L) {
     return 1;
 }
 
+#define DEPRECATION_WARNING "require('tomlua.env'): deprecation warning:\nThis should not have been added to this library.\nAs such, it has been moved to a new package, `osenv`, at https://github.com/BirdeeHub/lua-osenv\nIn the future it will only be offered there.\n"
+
 int luaopen_tomlua_env(lua_State *L) {
+    lua_getglobal(L, "io");
+    if (lua_istable(L, -1)) {
+        lua_getfield(L, -1, "stderr");
+        if (!lua_isnil(L, -1)) {
+            lua_getfield(L, -1, "write");
+            if (lua_isfunction(L, -1)) {
+                lua_pushvalue(L, -2);  // stderr
+                lua_pushliteral(L, DEPRECATION_WARNING);
+                lua_call(L, 2, 0);
+            }
+        }
+    }
+    lua_settop(L, 0);
     lua_newtable(L); // module table
     lua_newtable(L); // metatable
     lua_pushcfunction(L, env__index);

--- a/tests/opts_test.lua
+++ b/tests/opts_test.lua
@@ -42,12 +42,3 @@ define("opts({ int_keys = true }) doesn't copy", function()
     local opts = tomlua.opts()
     ok(type(opts) == "table", "opts when called with no args should return a table")
 end)
-
-define("require('tomlua.env') tests", function()
-    local env = require("tomlua.env")
-    ok(env ~= nil, "tomlua.env should be available")
-    env.TESTVARIABLE = "HELLO"
-    ok(env.TESTVARIABLE == os.getenv("TESTVARIABLE"), "tomlua.env should get the env var")
-    env.TESTVARIABLE = nil
-    ok(env.TESTVARIABLE == os.getenv("TESTVARIABLE"), "tomlua.env should be removed just like the env var")
-end)


### PR DESCRIPTION
This does not belong here and I should not have added it yesterday. It gives more access than it is necessary for a toml parser or its cli command to have, and it can be added if desired.

https://github.com/BirdeeHub/lua-osenv

It has been moved to a new repository and given a few more features